### PR TITLE
Update dev dependencies to be a separate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ repos:
 
 ## Installation
 
-
 ```bash
 pip install git+https://github.com/swiss-ai-center/mdwrap.git@0.2.4
 ```
@@ -63,7 +62,6 @@ mdwrap [-h] [--print-width PRINT_WIDTH] [--fmt] [--unwrap] [--check]
        [--ignore IGNORE] [--ignore-extend IGNORE_EXTEND] [--version]
        targets [targets ...]
 ```
-
 
 ```bash
 # To format (wrap) a file:
@@ -117,7 +115,7 @@ source .venv/bin/activate
 Install the development dependencies:
 
 ```bash
-pip install .
+pip install -e '.[dev]'
 ```
 
 Install the pre-commit hooks:
@@ -156,6 +154,7 @@ git tag <version> main
 # Push the tag
 git push origin <version>
 ```
+
 4. Update the changes in the new
    [GitHub release](https://github.com/csia-pme/mdwrap/releases/latest).
 5. Finally, update the version in the pre-commit hook in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,13 @@ description = "A python based markdown line wrapper"
 authors = [
     { name = "Leonard", email = "leocser632@gmail.com" }
 ]
-dependencies = [
+readme = "README.md"
+license = { text = "MIT License" }
+requires-python = ">= 3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
     "pre-commit>=3.7.1",
     "black>=24.4.2",
     "flake8>=7.0.0",
@@ -16,11 +22,8 @@ dependencies = [
     "flake8-implicit-str-concat>=0.4.0",
     "isort>=5.13.2",
     "pytest>=8.2.1",
-    "build>=1.2.1",
+    "build>=1.2.1"
 ]
-readme = "README.md"
-license = { text = "MIT License" }
-requires-python = ">= 3.10"
 
 [project.scripts]
 mdwrap = "mdwrap.cli:cli"


### PR DESCRIPTION
Currently dev dependencies are included when installing mdwrap although it does not need them. To mitigate this, a new optional package called `dev` was added that contains the dev dependencies.

For more information see:
https://stackoverflow.com/questions/75049691/specifying-test-dependencies-in-pyproject-toml-and-getting-them-installed-with-p